### PR TITLE
Available Until

### DIFF
--- a/book-1-foundations/chapters/extravert-date.md
+++ b/book-1-foundations/chapters/extravert-date.md
@@ -10,8 +10,6 @@ This chapter will add the ability to provide an expiration date for a plant post
 1. Set the `AvailableUntil` property on the new `Plant` with the date created in the previous step.
 
 ## Refactoring the app to use `AvailableUntil`
-
-1. Update the view that shows the plants available for adoption to only include plants that are not sold _and_ are still available. You will have to compare the plant's `AvailableUntil` property to `DateTime.Now` to check this.
-1. Update the "Number of Available Plants" statistic to take this property into account as well.
+Update the view that shows the plants available for adoption to only include plants that are not sold _and_ are still available. You will have to compare the plant's `AvailableUntil` property to `DateTime.Now` to check this.
 
 Up Next: [App Statistics](./extravert-stats.md)

--- a/book-1-foundations/chapters/extravert-stats.md
+++ b/book-1-foundations/chapters/extravert-stats.md
@@ -10,7 +10,7 @@ In this chapter we will allow the user to view some statistics about the plants 
 | Stats                                  |
 | -------------------------------------- |
 | Lowest price plant name                |
-| Number of Plants Available (not sold)         |
+| Number of Plants Available (not sold, and still available)|
 | Name of plant with highest light needs |
 | Average light needs                    |
 | Percentage of plants adopted           |


### PR DESCRIPTION
The "Available Until" chapter of Extravert refers to the statistics chapter before it has been implemented. Moving the instruction to use the `AvailableUntil` property to filter available plants until that is implemented in the next chapter. 